### PR TITLE
Rename to <foo>Middleware

### DIFF
--- a/cacheMiddleware/cache.go
+++ b/cacheMiddleware/cache.go
@@ -1,4 +1,4 @@
-package cache // import "github.com/teamwork/middleware/cache"
+package cacheMiddleware // import "github.com/teamwork/middleware/cacheMiddleware"
 
 import "net/http"
 

--- a/contenttypeMiddleware/contentType.go
+++ b/contenttypeMiddleware/contentType.go
@@ -1,4 +1,4 @@
-package contenttype // import "github.com/teamwork/middleware/contenttype"
+package contenttypeMiddleware // import "github.com/teamwork/middleware/contenttypeMiddleware"
 
 import (
 	"mime"

--- a/corsMiddleware/cors.go
+++ b/corsMiddleware/cors.go
@@ -1,4 +1,4 @@
-package cors // import "github.com/teamwork/middleware/cors"
+package corsMiddleware // import "github.com/teamwork/middleware/corsMiddleware"
 
 import (
 	"net/http"

--- a/httperrMiddleware/error.go
+++ b/httperrMiddleware/error.go
@@ -1,4 +1,4 @@
-package httperr // import "github.com/teamwork/middleware/httperr"
+package httperrMiddleware // import "github.com/teamwork/middleware/httperrMiddleware"
 
 import (
 	"mime"

--- a/httperrMiddleware/error_test.go
+++ b/httperrMiddleware/error_test.go
@@ -1,4 +1,4 @@
-package httperr // import "github.com/teamwork/middleware/httperr"
+package httperrMiddleware // import "github.com/teamwork/middleware/httperrMiddleware"
 
 import (
 	"errors"

--- a/jsonMiddleware/json.go
+++ b/jsonMiddleware/json.go
@@ -1,4 +1,4 @@
-package json // import "github.com/teamwork/middleware/json"
+package jsonMiddleware // import "github.com/teamwork/middleware/jsonMiddleware"
 
 import (
 	"mime"

--- a/logMiddleware/reqlog.go
+++ b/logMiddleware/reqlog.go
@@ -1,4 +1,4 @@
-package reqlog // import "github.com/teamwork/middleware/reqlog"
+package logMiddleware // import "github.com/teamwork/middleware/logMiddleware"
 
 import (
 	"fmt"

--- a/pathMiddleware/path.go
+++ b/pathMiddleware/path.go
@@ -1,4 +1,4 @@
-package path // import "github.com/teamwork/middleware/path"
+package pathMiddleware // import "github.com/teamwork/middleware/pathMiddleware"
 
 import (
 	"net/http"

--- a/ratelimitMiddleware/ratelimiter.go
+++ b/ratelimitMiddleware/ratelimiter.go
@@ -1,4 +1,4 @@
-package ratelimiter // import "github.com/teamwork/middleware/ratelimiter"
+package ratelimitMiddleware // import "github.com/teamwork/middleware/ratelimitMiddleware"
 
 import (
 	"fmt"

--- a/rescueMiddleware/rescue.go
+++ b/rescueMiddleware/rescue.go
@@ -1,8 +1,8 @@
-// Package rescue is a middleware to recover() and log panic()s.
+// Package rescueMiddleware recover()s and log panic()s.
 //
 // It will also return an appropriate response to the client (HTML, JSON, or
 // text).
-package rescue // import "github.com/teamwork/middleware/rescue"
+package rescueMiddleware // import "github.com/teamwork/middleware/rescueMiddleware"
 
 import (
 	"encoding/json"

--- a/securityMiddleware/security.go
+++ b/securityMiddleware/security.go
@@ -1,4 +1,4 @@
-package security // import "github.com/teamwork/middleware/security"
+package securityMiddleware // import "github.com/teamwork/middleware/securityMiddleware"
 
 import (
 	"fmt"


### PR DESCRIPTION
Otherwise it can be very annoying to use, as `cache`, `path`, `json`
etc. are also common package and/or variable names.

It's a bit ugly and mouthful, but these packages are usually only used
once or twice, so it's probably okay (we have the same pattern with
controlers in desk: `ticketsContoller`, `customerController`, etc.)