### PR TITLE
Fix rescue middleware

### DIFF
--- a/rescueMiddleware/rescue.go
+++ b/rescueMiddleware/rescue.go
@@ -15,63 +15,65 @@ import (
 	"github.com/teamwork/log"
 )
 
-// Handle recovers and logs panics in any of the lower middleware or HTTP
-// handlers.
+// Rescue from panic()s in any of the lower middleware or HTTP handlers.
 //
 // The extraFields callback can be used to add extra fields to the log (such as
 // perhaps a installation ID or user ID from the session).
-func Handle(extraFields func(*log.Entry) *log.Entry, dev bool) func(http.Handler) http.Handler {
+func Rescue(extraFields func(*log.Entry) *log.Entry, dev bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			l := log.Module("panic handler")
 			defer func() {
-				if rec := recover(); r != nil {
-					var err error
-					switch rec := rec.(type) {
-					case error:
-						err = rec
-					case map[string]interface{}:
-						err, _ = rec["error"].(error)
-					default:
-						err = pretty.Errorf("%v", rec)
-					}
-
-					if extraFields != nil {
-						l = extraFields(l)
-					}
-
-					// Report to Sentry.
-					l.Err(err)
-
-					w.WriteHeader(http.StatusInternalServerError)
-
-					switch {
-					// Show panic in browser on dev.
-					case dev:
-						if r.Header.Get("X-Requested-With") == "XMLHttpRequest" {
-							w.Write([]byte(err.Error())) // nolint: errcheck
-							return
-						}
-
-						// nolint: errcheck
-						w.Write([]byte(fmt.Sprintf("<h2>%v</h2><pre>%s</pre>",
-							err, debug.Stack())))
-
-					// JSON response for AJAX.
-					case r.Header.Get("X-Requested-With") == "XMLHttpRequest":
-						b, _ := json.Marshal(map[string]interface{}{
-							"message": "Sorry, the server ran into a problem processing this request.",
-						})
-						w.Header().Add("Content-Type", "application/json")
-						w.Write(b) // nolint: errcheck
-
-					// Well, just fall back to text..
-					default:
-						w.Write([]byte("Sorry, the server ran into a problem processing this request.")) // nolint: errcheck
-					}
-
+				rec := recover()
+				if rec == nil {
 					return
 				}
+
+				var err error
+				switch rec := rec.(type) {
+				case error:
+					err = rec
+				case map[string]interface{}:
+					err, _ = rec["error"].(error)
+				default:
+					err = pretty.Errorf("%v", rec)
+				}
+
+				if extraFields != nil {
+					l = extraFields(l)
+				}
+
+				// Report to Sentry.
+				l.Err(err)
+
+				w.WriteHeader(http.StatusInternalServerError)
+
+				switch {
+				// Show panic in browser on dev.
+				case dev:
+					if r.Header.Get("X-Requested-With") == "XMLHttpRequest" {
+						w.Write([]byte(err.Error())) // nolint: errcheck
+						return
+					}
+
+					// nolint: errcheck
+					w.Write([]byte(fmt.Sprintf("<h2>%v</h2><pre>%s</pre>",
+						err, debug.Stack())))
+
+				// JSON response for AJAX.
+				case r.Header.Get("X-Requested-With") == "XMLHttpRequest":
+					b, _ := json.Marshal(map[string]interface{}{
+						"message": "Sorry, the server ran into a problem processing this request.",
+					})
+					w.Header().Add("Content-Type", "application/json")
+					w.Write(b) // nolint: errcheck
+
+				// Fall back to text.
+				default:
+					w.Write([]byte("Sorry, the server ran into a problem processing this request.")) // nolint: errcheck
+				}
+
+				return
 			}()
 
 			next.ServeHTTP(w, r)

--- a/rescueMiddleware/rescue_test.go
+++ b/rescueMiddleware/rescue_test.go
@@ -1,0 +1,46 @@
+package rescueMiddleware
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/teamwork/test"
+)
+
+type handle struct{}
+
+func (h handle) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte("handler"))
+
+}
+
+func TestRescue(t *testing.T) {
+	rr := test.HTTP(t, nil, Rescue(nil, false)(handle{}).ServeHTTP)
+
+	if rr.Code != 200 {
+		t.Errorf("want code %v, got %v", 200, rr.Code)
+	}
+	if b := rr.Body.String(); b != "handler" {
+		t.Errorf("body wrong:\nwant: %#v\ngot:  %#v\n", "handler", b)
+	}
+}
+
+type panicy struct{}
+
+func (h panicy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	panic("oh noes!")
+
+}
+
+func TestRescuePanic(t *testing.T) {
+	rr := test.HTTP(t, nil, Rescue(nil, false)(panicy{}).ServeHTTP)
+
+	if rr.Code != 500 {
+		t.Errorf("want code %v, got %v", 200, rr.Code)
+	}
+
+	want := "Sorry, the server ran into a problem processing this request."
+	if b := rr.Body.String(); b != want {
+		t.Errorf("body wrong:\nwant: %#v\ngot:  %#v\n", want, b)
+	}
+}


### PR DESCRIPTION
Use `http.Handler` so we can use it with `echo.WrapMiddleware`; add
parameter for dev.

Needs more work, but this way I can use it in mailchecker/echo3.