### PR TITLE
Properly check for JSON Content-Type in audit filter

### DIFF
--- a/auditMiddleware/audit.go
+++ b/auditMiddleware/audit.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"mime"
 	"net/http"
 	"net/url"
 	"strings"
@@ -14,7 +13,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/teamwork/utils/httputilx"
-	"github.com/teamwork/utils/httputilx/header"
 	"github.com/teamwork/utils/sliceutil"
 )
 
@@ -210,7 +208,7 @@ func Middleware(opts Options, r *http.Request) {
 
 func (a *Audit) filterFields(r *http.Request, opts Options) {
 	body := make(map[string]interface{})
-	bodyIsJSON := isBodyJSON(r)
+	bodyIsJSON := strings.HasPrefix(strings.ToLower(r.Header.Get("Content-Type")), "application/json")
 
 	if bodyIsJSON && len(a.RequestBody) > 0 {
 		err := json.Unmarshal(a.RequestBody, &body)
@@ -245,15 +243,4 @@ func (a *Audit) filterFields(r *http.Request, opts Options) {
 
 		a.RequestBody = b
 	}
-}
-
-func isBodyJSON(r *http.Request) bool {
-	for _, spec := range header.ParseAccept(r.Header, "Accept") {
-		ct, _, _ := mime.ParseMediaType(spec.Value)
-		if ct == "application/json" {
-			return true
-		}
-	}
-
-	return false
 }

--- a/auditMiddleware/audit_test.go
+++ b/auditMiddleware/audit_test.go
@@ -121,7 +121,7 @@ func TestAudit(t *testing.T) {
 					RawQuery: "x=xyz",
 				},
 				Form:       url.Values{"w00t": []string{"XXX"}, "asd": []string{"zxcv", "qweqwe"}},
-				Header:     http.Header{"Some-Val": []string{"asd"}, "Accept": []string{"application/json"}},
+				Header:     http.Header{"Some-Val": []string{"asd"}, "Content-Type": []string{"application/json"}},
 				ProtoMajor: 1,
 				ProtoMinor: 1,
 				Body:       ioutil.NopCloser(strings.NewReader("{\"password\": \"my test\"}")),
@@ -136,8 +136,8 @@ func TestAudit(t *testing.T) {
 				Path:           "/foo",
 				Method:         "POST",
 				RequestHeaders: Header{http.Header{
-					"Some-Val": []string{"asd"},
-					"Accept":   []string{"application/json"},
+					"Some-Val":     []string{"asd"},
+					"Content-Type": []string{"application/json"},
 				}},
 				QueryParams: Values{url.Values{
 					"x": []string{"xyz"},
@@ -161,7 +161,7 @@ func TestAudit(t *testing.T) {
 					RawQuery: "x=xyz",
 				},
 				Form:       url.Values{"w00t": []string{"XXX"}, "asd": []string{"zxcv", "qweqwe"}},
-				Header:     http.Header{"Some-Val": []string{"asd"}, "Accept": []string{"text/plain"}},
+				Header:     http.Header{"Some-Val": []string{"asd"}, "Content-Type": []string{"text/plain"}},
 				ProtoMajor: 1,
 				ProtoMinor: 1,
 				Body:       ioutil.NopCloser(strings.NewReader("password: my test")),
@@ -176,8 +176,8 @@ func TestAudit(t *testing.T) {
 				Path:           "/foo",
 				Method:         "POST",
 				RequestHeaders: Header{http.Header{
-					"Some-Val": []string{"asd"},
-					"Accept":   []string{"text/plain"},
+					"Some-Val":     []string{"asd"},
+					"Content-Type": []string{"text/plain"},
 				}},
 				QueryParams: Values{url.Values{
 					"x": []string{"xyz"},


### PR DESCRIPTION
It was checking the `Accept` header, which specifies what kind of
content is acceptable for the *response*, but not what the *request*
actually is. That is what the `Content-Type` header does, so use that.

Fixes: https://sentry.io/teamwork/launchpad/issues/525470346