### PR TITLE
Update ratelimit headers

### DIFF
--- a/ratelimitMiddleware/ratelimiter.go
+++ b/ratelimitMiddleware/ratelimiter.go
@@ -104,9 +104,9 @@ func RateLimit(opts Config) func(http.Handler) http.Handler {
 				granted = opts.GrantOnErr
 			}
 
-			w.Header().Add("X-Rate-Limit-Limit", strconv.Itoa(perPeriodLocal))
-			w.Header().Add("X-Rate-Limit-Remaining", strconv.Itoa(remaining))
-			w.Header().Add("X-Rate-Limit-Reset", strconv.Itoa(periodSecondsLocal))
+			w.Header().Add("X-RateLimit-Limit", strconv.Itoa(perPeriodLocal))
+			w.Header().Add("X-RateLimit-Remaining", strconv.Itoa(remaining))
+			w.Header().Add("X-RateLimit-Reset", strconv.Itoa(periodSecondsLocal))
 
 			if !granted {
 				w.WriteHeader(http.StatusTooManyRequests)

--- a/ratelimitMiddleware/ratelimiter.go
+++ b/ratelimitMiddleware/ratelimiter.go
@@ -100,7 +100,7 @@ func RateLimit(opts Config) func(http.Handler) http.Handler {
 			if err != nil {
 				opts.ErrorLog(err, "failed to check if access is granted")
 				// returns an extra header when redis is down
-				w.Header().Add("X-Rate-Limit-Err", "1")
+				w.Header().Add("X-RateLimit-Err", "1")
 				granted = opts.GrantOnErr
 			}
 


### PR DESCRIPTION
Changing the ratelimit headers to what we've been using already to make it consistent with old and new api. No need to change what is well known and working. 

x-rateLimit is a common term used by many publishers.
see https://developer.github.com/v3/rate_limit/ as an example

splitting the term ratelimit in two parts is just unnecessary. 

