### PR TITLE
Allow path matching in content type validation

### DIFF
--- a/contenttype/contentType.go
+++ b/contenttype/contentType.go
@@ -31,40 +31,57 @@ const (
 )
 
 // DefaultOptions for the Valid() middleware if options if nil.
-var DefaultOptions = &Options{
-	Methods:           []string{http.MethodPost, http.MethodPut, http.MethodDelete},
-	ValidContentTypes: []string{ContentTypeJSON, ContentTypeFormEncoded, ContentTypeFormData},
-	AllowEmpty:        false,
+var DefaultOptions = map[string]Options{
+	"": Options{
+		Methods:           []string{http.MethodPost, http.MethodPut, http.MethodDelete},
+		ValidContentTypes: []string{ContentTypeJSON, ContentTypeFormEncoded, ContentTypeFormData},
+		AllowEmpty:        false,
+	},
 }
 
 // JSON are options to allow only JSON for all requests verbs (GET included).
-var JSON = &Options{
-	Methods:           []string{},
-	ValidContentTypes: []string{ContentTypeJSON},
-	AllowEmpty:        false,
+var JSON = map[string]Options{
+	"": Options{
+		Methods:           []string{},
+		ValidContentTypes: []string{ContentTypeJSON},
+		AllowEmpty:        false,
+	},
 }
 
 // Validate ensures that the content type header is set and is one of the
 // allowed content types. This ONLY applies to POST, PUT, and DELETE requests.
-func Validate(opts *Options) func(http.Handler) http.Handler {
+//
+// The option key is the pathname to check; use an empty string for the default
+// options (this is mandatory).
+func Validate(opts map[string]Options) func(http.Handler) http.Handler {
 	if opts == nil {
 		opts = DefaultOptions
 	}
-	if len(opts.ValidContentTypes) == 0 {
-		panic("no valid Content-Type given")
+	for k := range opts {
+		if len(opts[k].ValidContentTypes) == 0 {
+			panic(fmt.Sprintf("no valid Content-Type given for %q", k))
+		}
+		for i := range opts[k].Methods {
+			opts[k].Methods[i] = strings.ToUpper(opts[k].Methods[i])
+		}
 	}
-	for i := range opts.Methods {
-		opts.Methods[i] = strings.ToUpper(opts.Methods[i])
+	if _, ok := opts[""]; !ok {
+		panic("no default options given")
 	}
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if len(opts.Methods) > 0 && !sliceutil.InStringSlice(opts.Methods, r.Method) {
+			opt, ok := opts[r.URL.Path]
+			if !ok {
+				opt = opts[""]
+			}
+
+			if len(opt.Methods) > 0 && !sliceutil.InStringSlice(opt.Methods, r.Method) {
 				next.ServeHTTP(w, r)
 				return
 			}
 
-			if opts.AllowEmpty && r.Header.Get("Content-Type") == "" {
+			if opt.AllowEmpty && r.Header.Get("Content-Type") == "" {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -77,7 +94,7 @@ func Validate(opts *Options) func(http.Handler) http.Handler {
 				return
 			}
 
-			for _, valid := range opts.ValidContentTypes {
+			for _, valid := range opt.ValidContentTypes {
 				if ct == valid {
 					next.ServeHTTP(w, r)
 					return
@@ -86,7 +103,7 @@ func Validate(opts *Options) func(http.Handler) http.Handler {
 
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write([]byte(fmt.Sprintf("unknown content type: %v; must be one of %v",
-				ct, strings.Join(opts.ValidContentTypes, ", "))))
+				ct, strings.Join(opt.ValidContentTypes, ", "))))
 		})
 	}
 }

--- a/contenttype/contentType.go
+++ b/contenttype/contentType.go
@@ -89,7 +89,7 @@ func Validate(opts map[string]Options) func(http.Handler) http.Handler {
 			ct, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 			if ct == "" {
 				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write([]byte(fmt.Sprintf("invalid content type: %v",
+				_, _ = w.Write([]byte(fmt.Sprintf("invalid content type: %q",
 					r.Header.Get("Content-Type"))))
 				return
 			}
@@ -102,8 +102,9 @@ func Validate(opts map[string]Options) func(http.Handler) http.Handler {
 			}
 
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(fmt.Sprintf("unknown content type: %v; must be one of %v",
-				ct, strings.Join(opt.ValidContentTypes, ", "))))
+			_, _ = w.Write([]byte(fmt.Sprintf(
+				"unknown content type: %q for %q; must be one of %v",
+				ct, r.URL.Path, strings.Join(opt.ValidContentTypes, ", "))))
 		})
 	}
 }

--- a/contenttype/contentType_test.go
+++ b/contenttype/contentType_test.go
@@ -3,6 +3,7 @@ package contenttype
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/teamwork/test"
@@ -105,15 +106,16 @@ func TestValidate(t *testing.T) {
 		},
 	}
 
-	for i, tc := range cases {
+	for i, tt := range cases {
 		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
-			rr := test.HTTP(t, tc.in, Validate(nil)(handle{}).ServeHTTP)
+			tt.in.URL = &url.URL{Path: "/"}
+			rr := test.HTTP(t, tt.in, Validate(nil)(handle{}).ServeHTTP)
 
-			if rr.Code != tc.wantCode {
-				t.Errorf("want code %v, got %v", tc.wantCode, rr.Code)
+			if rr.Code != tt.wantCode {
+				t.Errorf("want code %v, got %v", tt.wantCode, rr.Code)
 			}
-			if b := rr.Body.String(); b != tc.wantBody {
-				t.Errorf("body wrong:\nwant: %#v\ngot:  %#v\n", tc.wantBody, b)
+			if b := rr.Body.String(); b != tt.wantBody {
+				t.Errorf("body wrong:\nwant: %#v\ngot:  %#v\n", tt.wantBody, b)
 			}
 		})
 	}
@@ -122,7 +124,7 @@ func TestValidate(t *testing.T) {
 func TestValidateOptions(t *testing.T) {
 	cases := []struct {
 		in       *http.Request
-		opts     *Options
+		opts     map[string]Options
 		wantCode int
 	}{
 		{
@@ -132,10 +134,10 @@ func TestValidateOptions(t *testing.T) {
 					"Content-Type": []string{"woot/woot"},
 				},
 			},
-			&Options{
+			map[string]Options{"": {
 				Methods:           []string{"GET"},
 				ValidContentTypes: []string{"woot/woot"},
-			},
+			}},
 			http.StatusOK,
 		},
 		{
@@ -145,10 +147,10 @@ func TestValidateOptions(t *testing.T) {
 					"Content-Type": []string{"woot"},
 				},
 			},
-			&Options{
+			map[string]Options{"": {
 				Methods:           []string{"GET"},
 				ValidContentTypes: []string{"woot/woot"},
-			},
+			}},
 			http.StatusBadRequest,
 		},
 		{
@@ -176,21 +178,60 @@ func TestValidateOptions(t *testing.T) {
 				Method: http.MethodPost,
 				Header: http.Header{},
 			},
-			&Options{
+			map[string]Options{"": {
 				Methods:           []string{http.MethodPost, http.MethodPut, http.MethodDelete},
 				ValidContentTypes: []string{ContentTypeJSON, ContentTypeFormEncoded, ContentTypeFormData},
 				AllowEmpty:        true,
+			}},
+			http.StatusOK,
+		},
+	}
+
+	for i, tt := range cases {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			tt.in.URL = &url.URL{Path: "/"}
+			rr := test.HTTP(t, tt.in, Validate(tt.opts)(handle{}).ServeHTTP)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("want code %v, got %v", tt.wantCode, rr.Code)
+			}
+		})
+	}
+}
+
+func TestPathMatch(t *testing.T) {
+	cases := []struct {
+		in       *http.Request
+		opts     map[string]Options
+		wantCode int
+	}{
+		{
+			&http.Request{
+				URL:    &url.URL{Path: "/foo"},
+				Method: http.MethodGet,
+				Header: http.Header{
+					"Content-Type": []string{"woot/woot"},
+				},
+			},
+			map[string]Options{
+				"": {
+					Methods:           []string{"GET"},
+					ValidContentTypes: []string{"asd/def"},
+				},
+				"/foo": {
+					Methods:           []string{"GET"},
+					ValidContentTypes: []string{"woot/woot"},
+				},
 			},
 			http.StatusOK,
 		},
 	}
 
-	for i, tc := range cases {
+	for i, tt := range cases {
 		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
-			rr := test.HTTP(t, tc.in, Validate(tc.opts)(handle{}).ServeHTTP)
-
-			if rr.Code != tc.wantCode {
-				t.Errorf("want code %v, got %v", tc.wantCode, rr.Code)
+			rr := test.HTTP(t, tt.in, Validate(tt.opts)(handle{}).ServeHTTP)
+			if rr.Code != tt.wantCode {
+				t.Errorf("want code %v, got %v", tt.wantCode, rr.Code)
 			}
 		})
 	}


### PR DESCRIPTION
For Hub I want one path to be a form request (for file uploads).