### PR TITLE
Enhancement: Add alternative interface for rate limit pool

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -62,7 +62,7 @@ gometalinter --deadline=240s --vendor --sort=path --tests --disable-all \
 	--enable=varcheck \
 	--enable=structcheck \
 	--enable=errcheck \
-	--enable=megacheck \
+	--enable=staticcheck \
 	--enable=ineffassign \
 	--enable=unconvert \
 	--enable=goconst \

--- a/ratelimit/ratelimiter.go
+++ b/ratelimit/ratelimiter.go
@@ -123,7 +123,13 @@ func RateLimit(opts Config) func(http.Handler) http.Handler {
 }
 
 // grant checks if the access is granted for this bucket key.
-var grant = func(ctx context.Context, opts *Config, key string, perPeriod, periodSeconds int) (granted bool, remaining int, err error) {
+var grant = func(
+	ctx context.Context,
+	opts *Config,
+	key string,
+	perPeriod, periodSeconds int,
+) (granted bool, remaining int, err error) {
+
 	accessTime := now().UnixNano()
 	duration, err := time.ParseDuration(fmt.Sprintf("%ds", periodSeconds))
 	if err != nil {

--- a/ratelimit/ratelimiter.go
+++ b/ratelimit/ratelimiter.go
@@ -2,6 +2,7 @@
 package ratelimit // import "github.com/teamwork/middleware/ratelimit"
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -28,6 +29,10 @@ var now = func() time.Time { return time.Now() }
 
 type redisPool interface {
 	Get() redis.Conn
+}
+
+type redisPoolCtx interface {
+	GetWithContext(ctx context.Context) redis.Conn
 }
 
 // Config for RateLimit
@@ -95,7 +100,7 @@ func RateLimit(opts Config) func(http.Handler) http.Handler {
 			}
 
 			key := opts.GetKey(r)
-			granted, remaining, err := grant(&opts, key, perPeriodLocal, periodSecondsLocal)
+			granted, remaining, err := grant(r.Context(), &opts, key, perPeriodLocal, periodSecondsLocal)
 			if err != nil {
 				opts.ErrorLog(err, "failed to check if access is granted")
 				// returns an extra header when redis is down
@@ -118,14 +123,23 @@ func RateLimit(opts Config) func(http.Handler) http.Handler {
 }
 
 // grant checks if the access is granted for this bucket key.
-var grant = func(opts *Config, key string, perPeriod, periodSeconds int) (granted bool, remaining int, err error) {
+var grant = func(ctx context.Context, opts *Config, key string, perPeriod, periodSeconds int) (granted bool, remaining int, err error) {
 	accessTime := now().UnixNano()
 	duration, err := time.ParseDuration(fmt.Sprintf("%ds", periodSeconds))
 	if err != nil {
 		return false, 0, err
 	}
 
-	conn := opts.Pool.Get()
+	var conn redis.Conn
+	if poolCtx, ok := opts.Pool.(redisPoolCtx); ok {
+		// Optional approach to retrieve the pool injecting the request context.
+		// Useful for encapsulating the pool layer for request specific behaviours
+		// (e.g. DataDog tracer).
+		conn = poolCtx.GetWithContext(ctx)
+	} else {
+		conn = opts.Pool.Get()
+	}
+
 	defer func() {
 		err := conn.Close()
 		if err != nil {

--- a/ratelimit/ratelimiter_test.go
+++ b/ratelimit/ratelimiter_test.go
@@ -1,6 +1,7 @@
 package ratelimit
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -24,7 +25,7 @@ func TestRateLimit(t *testing.T) {
 		getKey       func(*http.Request) string
 		ignore       func(*http.Request) bool
 		grantOnErr   bool
-		grantFunc    func(*Config, string, int, int) (bool, int, error)
+		grantFunc    func(context.Context, *Config, string, int, int) (bool, int, error)
 		rates        func(req *http.Request) (int, int)
 		expectedCode int
 	}{
@@ -34,7 +35,7 @@ func TestRateLimit(t *testing.T) {
 			ignore: func(req *http.Request) bool {
 				return false
 			},
-			grantFunc: func(opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
+			grantFunc: func(ctx context.Context, opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
 				return true, 0, nil
 			},
 			getKey: func(req *http.Request) string {
@@ -49,7 +50,7 @@ func TestRateLimit(t *testing.T) {
 			ignore: func(req *http.Request) bool {
 				return true
 			},
-			grantFunc: func(opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
+			grantFunc: func(ctx context.Context, opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
 				return false, 0, nil
 			},
 			getKey: func(req *http.Request) string {
@@ -64,7 +65,7 @@ func TestRateLimit(t *testing.T) {
 			ignore: func(req *http.Request) bool {
 				return false
 			},
-			grantFunc: func(opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
+			grantFunc: func(ctx context.Context, opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
 				return false, 0, nil
 			},
 			getKey: func(req *http.Request) string {
@@ -79,7 +80,7 @@ func TestRateLimit(t *testing.T) {
 			ignore: func(req *http.Request) bool {
 				return false
 			},
-			grantFunc: func(opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
+			grantFunc: func(ctx context.Context, opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
 				return false, 0, fmt.Errorf("test")
 			},
 			getKey: func(req *http.Request) string {
@@ -94,7 +95,7 @@ func TestRateLimit(t *testing.T) {
 			ignore: func(req *http.Request) bool {
 				return false
 			},
-			grantFunc: func(opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
+			grantFunc: func(ctx context.Context, opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
 				return false, 0, fmt.Errorf("test")
 			},
 			getKey: func(req *http.Request) string {
@@ -109,7 +110,7 @@ func TestRateLimit(t *testing.T) {
 			ignore: func(req *http.Request) bool {
 				return false
 			},
-			grantFunc: func(opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
+			grantFunc: func(ctx context.Context, opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
 				if perPeriodLocal != 2 {
 					return false, 0, fmt.Errorf("unexpected perPeriod %d", perPeriodLocal)
 				}
@@ -238,7 +239,7 @@ func TestGrant(t *testing.T) {
 			conn.Clear()
 			tt.stub()
 
-			granted, remaining, err := grant(&Config{Pool: mockRedisPool}, "test", 2, 60)
+			granted, remaining, err := grant(context.Background(), &Config{Pool: mockRedisPool}, "test", 2, 60)
 
 			if tt.expectedError != nil && !test.ErrorContains(err, tt.expectedError.Error()) {
 				t.Fatalf("wrong error: %v", err)

--- a/ratelimit/ratelimiter_test.go
+++ b/ratelimit/ratelimiter_test.go
@@ -35,7 +35,12 @@ func TestRateLimit(t *testing.T) {
 			ignore: func(req *http.Request) bool {
 				return false
 			},
-			grantFunc: func(ctx context.Context, opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
+			grantFunc: func(
+				ctx context.Context,
+				opts *Config,
+				k string,
+				perPeriodLocal, periodSecondsLocal int,
+			) (bool, int, error) {
 				return true, 0, nil
 			},
 			getKey: func(req *http.Request) string {
@@ -50,7 +55,12 @@ func TestRateLimit(t *testing.T) {
 			ignore: func(req *http.Request) bool {
 				return true
 			},
-			grantFunc: func(ctx context.Context, opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
+			grantFunc: func(
+				ctx context.Context,
+				opts *Config,
+				k string,
+				perPeriodLocal, periodSecondsLocal int,
+			) (bool, int, error) {
 				return false, 0, nil
 			},
 			getKey: func(req *http.Request) string {
@@ -65,7 +75,12 @@ func TestRateLimit(t *testing.T) {
 			ignore: func(req *http.Request) bool {
 				return false
 			},
-			grantFunc: func(ctx context.Context, opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
+			grantFunc: func(
+				ctx context.Context,
+				opts *Config,
+				k string,
+				perPeriodLocal, periodSecondsLocal int,
+			) (bool, int, error) {
 				return false, 0, nil
 			},
 			getKey: func(req *http.Request) string {
@@ -80,7 +95,12 @@ func TestRateLimit(t *testing.T) {
 			ignore: func(req *http.Request) bool {
 				return false
 			},
-			grantFunc: func(ctx context.Context, opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
+			grantFunc: func(
+				ctx context.Context,
+				opts *Config,
+				k string,
+				perPeriodLocal, periodSecondsLocal int,
+			) (bool, int, error) {
 				return false, 0, fmt.Errorf("test")
 			},
 			getKey: func(req *http.Request) string {
@@ -95,7 +115,12 @@ func TestRateLimit(t *testing.T) {
 			ignore: func(req *http.Request) bool {
 				return false
 			},
-			grantFunc: func(ctx context.Context, opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
+			grantFunc: func(
+				ctx context.Context,
+				opts *Config,
+				k string,
+				perPeriodLocal, periodSecondsLocal int,
+			) (bool, int, error) {
 				return false, 0, fmt.Errorf("test")
 			},
 			getKey: func(req *http.Request) string {
@@ -110,7 +135,12 @@ func TestRateLimit(t *testing.T) {
 			ignore: func(req *http.Request) bool {
 				return false
 			},
-			grantFunc: func(ctx context.Context, opts *Config, k string, perPeriodLocal, periodSecondsLocal int) (bool, int, error) {
+			grantFunc: func(
+				ctx context.Context,
+				opts *Config,
+				k string,
+				perPeriodLocal, periodSecondsLocal int,
+			) (bool, int, error) {
 				if perPeriodLocal != 2 {
 					return false, 0, fmt.Errorf("unexpected perPeriod %d", perPeriodLocal)
 				}


### PR DESCRIPTION
Optional approach to retrieve the pool injecting the request context. Useful for encapsulating the pool layer for request specific behaviours (e.g. DataDog tracer).