### PR TITLE
Rate limiter: expire unused keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 	github.com/teamwork/utils v0.0.0-20171107171849-80cee17504c9
 	github.com/tomasen/realip v0.0.0-20171212133304-b5850897b7b5
 )
+
+go 1.13

--- a/ratelimit/ratelimiter_test.go
+++ b/ratelimit/ratelimiter_test.go
@@ -234,6 +234,7 @@ func TestGrant(t *testing.T) {
 				conn.Command("MULTI")
 				conn.Command("ZADD", "test", unixNano, unixNano).Expect("QUEUED")
 				conn.Command("ZREMRANGEBYSCORE", "test", 0, unixNano-duration.Nanoseconds()).Expect("QUEUED")
+				conn.Command("EXPIRE", "test", keyExpiration).Expect("QUEUED")
 				conn.Command("ZRANGE", "test", 0, -1).Expect("QUEUED")
 				conn.Command("EXEC").ExpectSlice(
 					1, // result for zadd
@@ -253,6 +254,7 @@ func TestGrant(t *testing.T) {
 				conn.Command("MULTI")
 				conn.Command("ZADD", "test", unixNano, unixNano).Expect(int64(1))
 				conn.Command("ZREMRANGEBYSCORE", "test", 0, unixNano-duration.Nanoseconds()).Expect(int64(1))
+				conn.Command("EXPIRE", "test", keyExpiration).Expect(int64(1))
 				conn.Command("ZRANGE", "test", 0, -1).Expect(int64(1))
 				conn.Command("EXEC").ExpectSlice(
 					1, // result for zadd


### PR DESCRIPTION
Self-explanatory, but there's no need to permanently keep these ephemeral keys 😊 