### PR TITLE
Rate limiter: switch IP detection lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rafaeljusto/redigomock v0.0.0-20170720131524-7ae0511314e9
+	github.com/ripexz/rip v1.0.1
 	github.com/teamwork/test v0.0.0-20170828180701-109d4a7e538b
 	github.com/teamwork/utils v0.0.0-20171107171849-80cee17504c9
-	github.com/tomasen/realip v0.0.0-20171212133304-b5850897b7b5
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -12,9 +12,9 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rafaeljusto/redigomock v0.0.0-20170720131524-7ae0511314e9 h1:AgFSzGRVSy1kZ8EBHycQc6qK9gVqhJnVI2H/dk2cY/Y=
 github.com/rafaeljusto/redigomock v0.0.0-20170720131524-7ae0511314e9/go.mod h1:JaY6n2sDr+z2WTsXkOmNRUfDy6FN0L6Nk7x06ndm4tY=
+github.com/ripexz/rip v1.0.1 h1:F6HfR11O5GdlI9W/peHY86HVYoYMvZxsRnZ56X4i3qA=
+github.com/ripexz/rip v1.0.1/go.mod h1:AwV/BSi/rkcMvnlmTN0NL/OXCRD1HFGMp362XH5wUTo=
 github.com/teamwork/test v0.0.0-20170828180701-109d4a7e538b h1:4P5E6x8RfIN5e1PSdlwl3UtqIrgxR8ZUPNlXjJGVoGo=
 github.com/teamwork/test v0.0.0-20170828180701-109d4a7e538b/go.mod h1:TIbx7tx6WHBjQeLRM4eWQZBL7kmBZ7/KI4x4v7Y5YmA=
 github.com/teamwork/utils v0.0.0-20171107171849-80cee17504c9 h1:Ygu9U9154Ed0ix+wRizgBN/QVKQ0WNv347NQ5gwD5YU=
 github.com/teamwork/utils v0.0.0-20171107171849-80cee17504c9/go.mod h1:rmPaJUVv426LGg3QR31m1N0bfpCdCVyh3dCWsJTQeDA=
-github.com/tomasen/realip v0.0.0-20171212133304-b5850897b7b5 h1:qmzfCoiF4NbgNyVDzqw1hEV2N71M4Tmu3CyOr8qQW6k=
-github.com/tomasen/realip v0.0.0-20171212133304-b5850897b7b5/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=

--- a/ratelimit/ratelimiter.go
+++ b/ratelimit/ratelimiter.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/pkg/errors"
-	"github.com/tomasen/realip"
+	"github.com/ripexz/rip"
 )
 
 var (
@@ -67,10 +67,12 @@ func SetRate(n int, d time.Duration) error {
 	return nil
 }
 
-// IPBucket is a generator of rate limit buckets based on client's IP address
-func IPBucket(prefix string) func(*http.Request) string {
+// IPBucket is a generator of rate limit buckets based on client's IP address.
+// Optional filter function can be passed in, defaults to finding first public IP,
+// see: https://godoc.org/github.com/ripexz/rip
+func IPBucket(prefix string, filter func([]string) (string, bool)) func(*http.Request) string {
 	return func(req *http.Request) string {
-		return fmt.Sprintf("%s-%s", prefix, realip.RealIP(req))
+		return fmt.Sprintf("%s-%s", prefix, rip.FromRequest(req, filter))
 	}
 }
 


### PR DESCRIPTION
Since https://github.com/tomasen/realip isn't really maintained I rewrote it to make it a little more customisable.

The main reason for this change is to allow custom parsing of `X-Forwarded-For` header which can easily be spoofed. However, AWS ELB appends the real client's IP address to the end of the header value.

---------------

For example:
1. Attacker with actual IP of `52.11.11.11` sends `192.168.1.100, 203.0.113.14, 52.99.99.99` as the header value
2. AWS appends real IP so the service receives `192.168.1.100, 203.0.113.14, 52.99.99.99, 52.11.11.11`
3. Default filtering from `tomasen/realip` skips the local (192...) address and returns `203.0.113.14` as actual IP.

The attacker could easily change the IP with every request and ever get rate limited (or however else IP parsing was applied). With the new lib you can pass the `rip.FilterAWS` func which grabs the last IP in the list, so in the example above we'd get `52.11.11.11` as the result.
Custom filtering is also supported so it's possible to adapt it to other/custom hosting providers.