### PR TITLE
Fix: Rate limit algorithm not covering the last request from the rate

### DIFF
--- a/ratelimit/ratelimiter.go
+++ b/ratelimit/ratelimiter.go
@@ -198,5 +198,10 @@ var grant = func(
 	}
 
 	remaining = perPeriod - len(keys)
-	return remaining >= 1, remaining, nil
+
+	// the reason why we consider remaining zero as valid is because we register
+	// the current request before counting. For example, if we have 1 request
+	// per minute allowed, even if I send a request every 60 seconds, the
+	// remaining would be still zero.
+	return remaining >= 0, remaining, nil
 }

--- a/ratelimit/ratelimiter_test.go
+++ b/ratelimit/ratelimiter_test.go
@@ -244,11 +244,29 @@ func TestGrant(t *testing.T) {
 					})
 			},
 		},
-
+		{
+			description: "it should grant access when there's the exactly limit on redis set",
+			granted:     true,
+			remaining:   0,
+			stub: func() {
+				unixNano := now().UnixNano()
+				conn.Command("MULTI")
+				conn.Command("ZADD", "test", unixNano, unixNano).Expect("QUEUED")
+				conn.Command("ZREMRANGEBYSCORE", "test", 0, unixNano-duration.Nanoseconds()).Expect("QUEUED")
+				conn.Command("EXPIRE", "test", keyExpiration).Expect("QUEUED")
+				conn.Command("ZRANGE", "test", 0, -1).Expect("QUEUED")
+				conn.Command("EXEC").ExpectSlice(
+					1, // result for zadd
+					0, // result for zrem
+					[]interface{}{ // result for zrange
+						[]byte("1"), []byte("2"),
+					})
+			},
+		},
 		{
 			description: "it should block access when there are more elements in redis than the limit",
 			granted:     false,
-			remaining:   0,
+			remaining:   -1,
 			stub: func() {
 				unixNano := now().UnixNano()
 				conn.Command("MULTI")
@@ -260,7 +278,7 @@ func TestGrant(t *testing.T) {
 					1, // result for zadd
 					0, // result for zrem
 					[]interface{}{ // result for zrange
-						[]byte("1"), []byte("2"),
+						[]byte("1"), []byte("2"), []byte("3"),
 					})
 			},
 		},


### PR DESCRIPTION
Change the remaining to also consider zero as granted to cover the last request from the rate.

The current algorithm does the following:
1. Add entry (from the current request) to Redis
2. Remove old entries (outside the period)
3. Count the number of entries

If we allow 1 request per minute, and send a request every 60 seconds, as we first add it to Redis, the step 3 would return 1, and the calculation from `perPeriod - len(keys)` will return 0. The current implementation considers zero as not granted when it should.