### PR TITLE
Use Set for the rate limit headers

### DIFF
--- a/ratelimit/ratelimiter.go
+++ b/ratelimit/ratelimiter.go
@@ -113,9 +113,9 @@ func RateLimit(opts Config) func(http.Handler) http.Handler {
 				granted = opts.GrantOnErr
 			}
 
-			w.Header().Add("X-Rate-Limit-Limit", strconv.Itoa(perPeriodLocal))
-			w.Header().Add("X-Rate-Limit-Remaining", strconv.Itoa(remaining))
-			w.Header().Add("X-Rate-Limit-Reset", strconv.Itoa(periodSecondsLocal))
+			w.Header().Set("X-Rate-Limit-Limit", strconv.Itoa(perPeriodLocal))
+			w.Header().Set("X-Rate-Limit-Remaining", strconv.Itoa(remaining))
+			w.Header().Set("X-Rate-Limit-Reset", strconv.Itoa(periodSecondsLocal))
 
 			if !granted {
 				w.WriteHeader(http.StatusTooManyRequests)


### PR DESCRIPTION
It's possible that the values were getting duplicated and being comma separated